### PR TITLE
Initial fixes

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,585 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[AbstractFFTs]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "051c95d6836228d120f5f4b984dd5aba1624f716"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "0.5.0"
+
+[[ArgCheck]]
+git-tree-sha1 = "dedbbb2ddb876f899585c4ec4433265e3017215a"
+uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+version = "2.1.0"
+
+[[ArrayInterface]]
+deps = ["LinearAlgebra", "Requires", "SparseArrays"]
+git-tree-sha1 = "a2b4a1b7c725297565105f98dcee04e362d955d6"
+uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+version = "2.12.0"
+
+[[AverageShiftedHistograms]]
+deps = ["LinearAlgebra", "RecipesBase", "Statistics", "StatsBase", "UnicodePlots"]
+git-tree-sha1 = "a8e14a9cc9c696975aac7efa0d65a541296e1edd"
+uuid = "77b51b56-6f8f-5c3a-9cb4-d71f9594ea6e"
+version = "0.8.4"
+
+[[BangBang]]
+deps = ["Compat", "ConstructionBase", "Future", "InitialValues", "LinearAlgebra", "Requires", "Setfield", "Tables", "ZygoteRules"]
+git-tree-sha1 = "f42321255afc37da855b6cd9f2a1fc36c017ceee"
+uuid = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
+version = "0.3.29"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[CSV]]
+deps = ["CategoricalArrays", "DataFrames", "Dates", "Mmap", "Parsers", "PooledArrays", "SentinelArrays", "Tables", "Unicode"]
+git-tree-sha1 = "a390152e6850405a48ca51bd7ca33d11a21d6230"
+uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+version = "0.7.7"
+
+[[Calculus]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
+uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
+version = "0.5.1"
+
+[[CategoricalArrays]]
+deps = ["DataAPI", "Future", "JSON", "Missings", "Printf", "Statistics", "StructTypes", "Unicode"]
+git-tree-sha1 = "e7cb4f23938914f09afae58b611a59f3aa8d8f66"
+uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+version = "0.8.2"
+
+[[Combinatorics]]
+git-tree-sha1 = "08c8b6831dc00bfea825826be0bc8336fc369860"
+uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+version = "1.0.2"
+
+[[CommonSubexpressions]]
+deps = ["MacroTools", "Test"]
+git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.3.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "215f1c81cfd1c5416cd78740bff8ef59b24cd7c0"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.15.0"
+
+[[CompilerSupportLibraries_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "7c4f882c41faa72118841185afc58a2eb00ef612"
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "0.3.3+0"
+
+[[CompositionsBase]]
+git-tree-sha1 = "f3955eb38944e5dd0fabf8ca1e267d94941d34a5"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.0"
+
+[[ConstructionBase]]
+git-tree-sha1 = "a2a6a5fea4d6f730ec4c18a76d27ec10e8ec1c50"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.0.0"
+
+[[CpuId]]
+deps = ["Markdown", "Test"]
+git-tree-sha1 = "f0464e499ab9973b43c20f8216d088b61fda80c6"
+uuid = "adafc99b-e345-5852-983c-f28acb93d879"
+version = "0.2.2"
+
+[[Crayons]]
+git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.0.4"
+
+[[DataAPI]]
+git-tree-sha1 = "176e23402d80e7743fc26c19c681bfb11246af32"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.3.0"
+
+[[DataFrames]]
+deps = ["CategoricalArrays", "Compat", "DataAPI", "Future", "InvertedIndices", "IteratorInterfaceExtensions", "Missings", "PooledArrays", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "a7c1c9a6e47a92321bbc9d500dab9b04cc4a6a39"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "0.21.7"
+
+[[DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "6189e66c78a2d840db5ee530ac2326505b3cc7ae"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.4"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DefineSingletons]]
+git-tree-sha1 = "1a356f194281dff9ef1119faa9125a0d4e210729"
+uuid = "244e2a9f-e319-4986-a169-4d1fe445cd52"
+version = "0.1.0"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[DensityRatioEstimation]]
+deps = ["LinearAlgebra", "Parameters", "Requires", "Statistics", "StatsBase"]
+git-tree-sha1 = "3218d4e75988e8780b7535d87f332b6ed5192b45"
+uuid = "ab46fb84-d57c-11e9-2f65-6f72e4a7229f"
+version = "0.4.2"
+
+[[DiffEqDiffTools]]
+deps = ["ArrayInterface", "LinearAlgebra", "Requires", "SparseArrays", "StaticArrays"]
+git-tree-sha1 = "a4ed8a740484627ea41b47f7e1a25dd909a28353"
+uuid = "01453d9d-ee7c-5054-8395-0335cb756afa"
+version = "1.7.0"
+
+[[DiffResults]]
+deps = ["StaticArrays"]
+git-tree-sha1 = "da24935df8e0c6cf28de340b958f6aac88eaa0cc"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "1.0.2"
+
+[[DiffRules]]
+deps = ["NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "eb0c34204c8410888844ada5359ac8b96292cfd1"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "1.0.1"
+
+[[DimensionalData]]
+deps = ["ConstructionBase", "Dates", "LinearAlgebra", "RecipesBase", "SparseArrays", "Statistics", "Tables"]
+git-tree-sha1 = "fad55f8596a497ba605969f5cd6c9cf3d05b0464"
+repo-rev = "dataset"
+repo-url = "https://github.com/rafaqz/DimensionalData.jl.git"
+uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
+version = "0.12.1"
+
+[[Distances]]
+deps = ["LinearAlgebra", "Statistics"]
+git-tree-sha1 = "bed62cc5afcff16de797a9f38fb358b74071f785"
+uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+version = "0.9.0"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Distributions]]
+deps = ["FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "9c41285c57c6e0d73a21ed4b65f6eec34805f937"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.23.8"
+
+[[FFTW]]
+deps = ["AbstractFFTs", "FFTW_jll", "IntelOpenMP_jll", "Libdl", "LinearAlgebra", "MKL_jll", "Reexport"]
+git-tree-sha1 = "8b7c16b56936047ca41bf25effa137ae0b381ae8"
+uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+version = "1.2.4"
+
+[[FFTW_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "6c975cd606128d45d1df432fb812d6eb10fee00b"
+uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
+version = "3.3.9+5"
+
+[[FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "4863cbb7910079369e258dee4add9d06ead5063a"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.8.14"
+
+[[ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "NaNMath", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "1d090099fb82223abc48f7ce176d3f7696ede36d"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "0.10.12"
+
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
+[[GaussianSimulation]]
+deps = ["CpuId", "Distributions", "FFTW", "GeoStatsBase", "KrigingEstimators", "LinearAlgebra", "Statistics", "Variography"]
+git-tree-sha1 = "19d4118f68b01cbf6ae3e19914ddf6eb52b2b2a2"
+uuid = "e40f437e-72ad-4a71-a29e-78c1c8d897bb"
+version = "0.1.0"
+
+[[GeoStats]]
+deps = ["GaussianSimulation", "GeoStatsBase", "KrigingEstimators", "PointPatterns", "Reexport", "Variography"]
+git-tree-sha1 = "8138eeea25d04fe8e7a9d8a984a87e3d29ab1893"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaEarth/GeoStats.jl.git"
+uuid = "dcc97b0b-8ce5-5539-9008-bb190f959ef6"
+version = "0.16.0"
+
+[[GeoStatsBase]]
+deps = ["AverageShiftedHistograms", "CSV", "CategoricalArrays", "Combinatorics", "DataFrames", "DensityRatioEstimation", "Distances", "Distributed", "Distributions", "LinearAlgebra", "LossFunctions", "MLJModelInterface", "NearestNeighbors", "Optim", "Parameters", "Random", "RecipesBase", "ScientificTypes", "SpecialFunctions", "StaticArrays", "Statistics", "StatsBase", "Tables", "Transducers"]
+git-tree-sha1 = "5e33581ecf8a0b16a96f0898f4063fc94068fae8"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaEarth/GeoStatsBase.jl.git"
+uuid = "323cb8eb-fbf6-51c0-afd0-f8fba70507b2"
+version = "0.13.0"
+
+[[InitialValues]]
+git-tree-sha1 = "26c8832afd63ac558b98a823265856670d898b6c"
+uuid = "22cec73e-a1b8-11e9-2c92-598750a2cf9c"
+version = "0.2.10"
+
+[[IntelOpenMP_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "fb8e1c7a5594ba56f9011310790e03b5384998d6"
+uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
+version = "2018.0.3+0"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[InvertedIndices]]
+deps = ["Test"]
+git-tree-sha1 = "15732c475062348b0165684ffe28e85ea8396afc"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.0.0"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.1"
+
+[[KrigingEstimators]]
+deps = ["Combinatorics", "Distances", "Distributions", "GeoStatsBase", "LinearAlgebra", "StaticArrays", "Statistics", "Variography"]
+git-tree-sha1 = "2991d53f9de7d5bfac187d12848103cef419ea9e"
+uuid = "d293930c-a38c-56c5-8ebb-12008647b47a"
+version = "0.4.3"
+
+[[LearnBase]]
+git-tree-sha1 = "a0d90569edd490b82fdc4dc078ea54a5a800d30a"
+uuid = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
+version = "0.4.1"
+
+[[LibGit2]]
+deps = ["Printf"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LineSearches]]
+deps = ["LinearAlgebra", "NLSolversBase", "NaNMath", "Parameters", "Printf"]
+git-tree-sha1 = "d6e6b2ed397a402a22e474a3f1859c8c1db82c8c"
+uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
+version = "7.1.0"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[LossFunctions]]
+deps = ["LearnBase", "Markdown", "RecipesBase", "SparseArrays", "StatsBase"]
+git-tree-sha1 = "3cd347266e394a066ca7f17bd8ff589ff5ce1d35"
+uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
+version = "0.6.2"
+
+[[MKL_jll]]
+deps = ["IntelOpenMP_jll", "Libdl", "Pkg"]
+git-tree-sha1 = "eb540ede3aabb8284cb482aa41d00d6ca850b1f8"
+uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
+version = "2020.2.254+0"
+
+[[MLJModelInterface]]
+deps = ["Random", "ScientificTypes"]
+git-tree-sha1 = "6d719b5831d2dffc579895e8070b65aa70322609"
+uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
+version = "0.3.5"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "f7d2e3f654af75f01ec49be82c231c382214223a"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.5"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "ed61674a0864832495ffe0a7e889c0da76b0f4c8"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "0.4.4"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[NLSolversBase]]
+deps = ["Calculus", "DiffEqDiffTools", "DiffResults", "Distributed", "ForwardDiff"]
+git-tree-sha1 = "f1b8ed89fa332f410cfc7c937682eb4d0b361521"
+uuid = "d41bc354-129a-5804-8e4c-c37616107c6c"
+version = "7.5.0"
+
+[[NaNMath]]
+git-tree-sha1 = "c84c576296d0e2fbb3fc134d3e09086b3ea617cd"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.4"
+
+[[NearestNeighbors]]
+deps = ["Distances", "StaticArrays"]
+git-tree-sha1 = "93107e3cdada73d63245ed8170dcae680f0c8fd8"
+uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
+version = "0.4.6"
+
+[[OpenSpecFun_jll]]
+deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
+git-tree-sha1 = "d51c416559217d974a1113522d5919235ae67a87"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.3+3"
+
+[[Optim]]
+deps = ["Compat", "FillArrays", "LineSearches", "LinearAlgebra", "NLSolversBase", "NaNMath", "Parameters", "PositiveFactorizations", "Printf", "SparseArrays", "StatsBase"]
+git-tree-sha1 = "c05aa6b694d426df87ff493306c1c5b4b215e148"
+uuid = "429524aa-4258-5aef-a3af-852621145aeb"
+version = "0.22.0"
+
+[[OrderedCollections]]
+git-tree-sha1 = "293b70ac1780f9584c89268a6e2a560d938a7065"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.3.0"
+
+[[PDMats]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse", "Test"]
+git-tree-sha1 = "b3405086eb6a974eba1958923d46bc0e1c2d2d63"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.10.0"
+
+[[Parameters]]
+deps = ["OrderedCollections", "UnPack"]
+git-tree-sha1 = "38b2e970043613c187bd56a995fe2e551821eb4a"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.12.1"
+
+[[Parsers]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "8077624b3c450b15c087944363606a6ba12f925e"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.0.10"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PointPatterns]]
+deps = ["Distributions", "GeoStatsBase", "RecipesBase"]
+git-tree-sha1 = "5be9e44c0eebf9187190760f65dc7f3673189867"
+uuid = "e61b41b6-3414-4803-863f-2b69057479eb"
+version = "0.2.2"
+
+[[PooledArrays]]
+deps = ["DataAPI"]
+git-tree-sha1 = "b1333d4eced1826e15adbdf01a4ecaccca9d353c"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "0.5.3"
+
+[[PositiveFactorizations]]
+deps = ["LinearAlgebra", "Test"]
+git-tree-sha1 = "127c47b91990c101ee3752291c4f45640eeb03d1"
+uuid = "85a6dd25-e78a-55b7-8502-1745935b8125"
+version = "0.2.3"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "12fbe86da16df6679be7521dfb39fbc861e1dc7b"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.4.1"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[RecipesBase]]
+git-tree-sha1 = "6ee6c35fe69e79e17c455a386c1ccdc66d9f7da4"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.1.0"
+
+[[Reexport]]
+deps = ["Pkg"]
+git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "0.2.0"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "8c08d0c7812169e438a8478dae2a529377ad13f7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.0.2"
+
+[[Rmath]]
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "86c5647b565873641538d8f812c04e4c9dbeb370"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.6.1"
+
+[[Rmath_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "d76185aa1f421306dec73c057aa384bad74188f0"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.2.2+1"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[ScientificTypes]]
+git-tree-sha1 = "3c88d3db0ffed7dabc94aa3d09798f97f1d7316f"
+uuid = "321657f4-b219-11e9-178b-2701a2544e81"
+version = "1.0.0"
+
+[[SentinelArrays]]
+deps = ["Dates", "Random"]
+git-tree-sha1 = "7a74946ace3b34fbb6c10e61b6e250b33d7e758c"
+uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
+version = "1.2.15"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Setfield]]
+deps = ["ConstructionBase", "Future", "MacroTools", "Requires"]
+git-tree-sha1 = "d5640fc570fb1b6c54512f0bd3853866bd298b3e"
+uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+version = "0.7.0"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures", "Random", "Test"]
+git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "0.3.1"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SpecialFunctions]]
+deps = ["OpenSpecFun_jll"]
+git-tree-sha1 = "d8d8b8a9f4119829410ecd706da4cc8594a1e020"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "0.10.3"
+
+[[SplittablesBase]]
+deps = ["Setfield", "Test"]
+git-tree-sha1 = "ab80edcbd61a44a4dc489d06ead964a863c0a898"
+uuid = "171d559e-b47b-412a-8079-5efa626c420e"
+version = "0.1.10"
+
+[[StaticArrays]]
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "016d1e1a00fabc556473b07161da3d39726ded35"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.12.4"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics"]
+git-tree-sha1 = "d72a47c47c522e283db774fc8c459dd5ed773710"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.33.1"
+
+[[StatsFuns]]
+deps = ["Rmath", "SpecialFunctions"]
+git-tree-sha1 = "04a5a8e6ab87966b43f247920eab053fd5fdc925"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "0.9.5"
+
+[[StructTypes]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "1ed04f622a39d2e5a6747c3a70be040c00333933"
+uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+version = "1.1.0"
+
+[[SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "b1ad568ba658d8cbb3b892ed5380a6f3e781a81e"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.0"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "b7f762e9820b7fab47544c36f26f54ac59cf8abf"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.0.5"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Transducers]]
+deps = ["ArgCheck", "BangBang", "CompositionsBase", "DefineSingletons", "Distributed", "InitialValues", "Logging", "Markdown", "Requires", "Setfield", "SplittablesBase", "Tables"]
+git-tree-sha1 = "3898a116e108a2b8d6b63051d158f3b904130331"
+uuid = "28d57a85-8fef-5791-bfe6-a80928e7c999"
+version = "0.4.51"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[UnPack]]
+git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "1.0.2"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[UnicodePlots]]
+deps = ["Crayons", "Dates", "SparseArrays", "StatsBase"]
+git-tree-sha1 = "1a63e6eea76b291378ff9f95801f8b6d96213208"
+uuid = "b8865327-cd53-5732-bb35-84acbb429228"
+version = "1.3.0"
+
+[[Variography]]
+deps = ["Distances", "GeoStatsBase", "InteractiveUtils", "Optim", "Parameters", "Printf", "RecipesBase", "SpecialFunctions", "StaticArrays", "Transducers"]
+git-tree-sha1 = "7a920506597e5540b960fe3b29d89d4fcdf1104a"
+uuid = "04a0146e-e6df-5636-8d7f-62fa9eb0b20c"
+version = "0.8.3"
+
+[[ZygoteRules]]
+deps = ["MacroTools"]
+git-tree-sha1 = "b3b4882cc9accf6731a08cc39543fbc6b669dca8"
+uuid = "700de1a5-db45-46bc-99cf-38207098b444"
+version = "0.2.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+GeoStats = "dcc97b0b-8ce5-5539-9008-bb190f959ef6"
+GeoStatsBase = "323cb8eb-fbf6-51c0-afd0-f8fba70507b2"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/dimdomain.jl
+++ b/dimdomain.jl
@@ -1,171 +1,88 @@
 
 # Need to use `] add DimensionalData#dataset` to get the latest things used here
 
-using DimensionalData, GeoStatsBase, GeoStats, Plots, BenchmarkTools,
-      DirectGaussianSimulation, Test, StaticArrays, LinearAlgebra, KrigingEstimators
+# we will extend behavior from:
+import GeoStatsBase
+import DimensionalData
 
-using DimensionalData: DimColumn
+# and users will use features from:
+using GeoStats
+using DimensionalData
+using Plots, Test
 
-
+# first we create a wrapper type for the underlying domain of a
+# dimensional array, similar to the wrapper DimTable for the values
 """
     DimDomain{C} <: AbstractDomain
 
-A domain object that can uses a tuple of `Dimension`s to generate coordinates.
+A wrapper for the underlying domain of an AbstractDimArray.
+
+See also DimTable.
 """
 struct DimDomain{C} <: AbstractDomain
     dimcolumns::C
 end
-dimcolumns(dom::DimDomain) = dom.dimcolumns
-# This syntax should be fixed in DD for DimColumn
-DimensionalData.dims(dom::DimDomain) = map(DimensionalData.dim, dimcolumns(dom))  
+GeoStatsBase.nelms(dom::DimDomain) = length(dom.dimcolumns)
+GeoStatsBase.ncoords(dom::DimDomain) = length(dims(dom.dimcolumns))
 
-# Domain interface for DimDomain
+# this should return the type of the lat/lon pairs, probably Float64
+# I will just hard code it for now
+GeoStatsBase.coordtype(dom::DimDomain) = Float64
 
-GeoStatsBase.nelms(dom::DimDomain) = length(first(dimcolumns(dom)))
-GeoStatsBase.ncoords(dom::DimDomain) = length(dimcolumns(dom))
-GeoStatsBase.coordtype(dom::DimDomain) = eltype(first(dimcolumns(dom)))
+# this should set the buf to contain the coordinates of the i-th cell
+# in the dimensional array
+GeoStatsBase.coordinates!(buf, dom::DimDomain, i) = @error "not implemented"
 
-# Why do we need both of these methods?
-GeoStatsBase.coordinates!(buf::AbstractVector, dom::DimDomain, i::Int) = 
-    buf[i] = SA[map(c -> c[i], dimcolumns(dom))...]
-GeoStatsBase.coordinates!(buf::MArray, dom::DimDomain, i::Int) =
-    buf .= map(c -> c[i], dimcolumns(dom))
-
-
-
-# Data interface
-
-"""
-    domain(dims::Tuple{Vararg{<:Dimension}})
-
-Get the domain from a tuple of Dimension
-"""
-GeoStatsBase.domain(dims::Tuple{Vararg{<:Dimension}}) = begin
-# Here we check if this these dimensions are all regular
-    isregular = map(dims) do d
-        mode(d) isa Sampled && span(d) isa Regular
-    end
-
-    # If they are regular, use the RegularGrid Domain
-    if all(isregular)
-        lengths = map(length, dims)
-        origins = map(first, dims)
-        steps = map(d -> val(span(d)), dims)
-        # RegularGrid could just accept AbstractRange?
-        RegularGrid(lengths, origins, steps)
-
-    # Otherwise, generate a DimDomain from the dimensions
-    else 
-        dimcolumns = map(d -> DimColumn(d, dims), dims)
-        DimDomain(dimcolumns) end
-end
-GeoStatsBase.domain(x::Union{AbstractDimArray,AbstractDimDataset}) = 
-    GeoStatsBase.domain(dims(A))
-
-"""
-    domain(A::AbstractDimArray)
-
-Get the domain from any AbstractDimArray
-"""
-GeoStatsBase.domain(A::AbstractDimArray) = GeoStatsBase.domain(dims(A))
-
-# This table also has the dimension columns in it, because its a general
-# tables interface. It should still work? 
+# now that we have both DimDomain and DimTable, let's just forward
+# them whenever we get a dimensional array
+GeoStatsBase.domain(A::AbstractDimArray) = DimDomain(A)
 GeoStatsBase.values(A::AbstractDimArray) = DimTable(A)
-
 
 """
     interpolate(da::AbstractDimArray, solver::AbstractSolver; dims=dims(da))
-    interpolate(ds::AbstractDimDataset, solver::AbstractSolver; dims=dims(ds))
 
-Either interpolate to fill missings in the current array, 
+Either interpolate to fill missings in the current array,
 or interpolate to a new domain specified by `dims`.
-
-If the passed in object is a `AbstractDimDataset`, all layers will be interpolated.
 """
 interpolate(da::AbstractDimArray, solver::AbstractSolver; dims=dims(da)) = begin
-    key = name(da)
-    data = SpatialData(domain(da), DimTable(da)) 
-    problem = EstimationProblem(data, domain(dims), key, mapper=CopyMapper())
-    sol = solve(problem, solver)
-    newA = reshape(sol[key][:mean], map(length, dims))
-    newdims = formatdims(newA, dims)
-    rebuild(da, newA, newdims)
+    # it seems that an abstract array stores a single layer?
+    # in this case, get the layer name, and interpolate on
+    # a possibly finer grid. how do we construct such grid?
+    # ideally we should be able to easily construct a DimDomain
+    # from the dims keyword argument. because I am not familiar
+    # with the DD.jl api, I think it is safer if you do it.
+    # for now I will just interpolate on the same original grid,
+    # effectively doing nothing
+    prob = EstimationProblem(da, domain(da), DimensionalData.name(da))
+    sol  = solve(prob, solver)
 end
-interpolate(ds::AbstractDimDataset, solver::AbstractSolver; dims=dims(ds)) =
-    map(da -> interpolate(da, solver; dims=dims), ds)
-
 
 #########################################################################
 # Tests
 
+@testset "Test simulation on DimDomain" begin
+    da = DimArray(rand(20, 30), (X(LinRange(-19.0, 19.0, 20)), Y(LinRange(3.0, 90.0, 30))))
 
-@testset "RegularGrid is detected where possible" begin
-    # Define a regular index DimArray
-    da_r = DimArray(rand(20, 30), (X(LinRange(-19.0, 19.0, 20)), Y(LinRange(3.0, 90.0, 30))))
-
-    # Get the domain from it
-    rg = GeoStatsBase.domain(da_r)
-
-    # It's a RegularGrid domain
-    @test rg isa RegularGrid
-
-    # Use it for something
-    P = SimulationProblem(rg, :Z => Float64, 2)
-    S = DirectGaussSim(:Z=>(variogram=GaussianVariogram(range=30.0),))
+    P = SimulationProblem(domain(da), :Z => Float64, 2)
+    S = LUGaussSim(:Z=>(variogram=GaussianVariogram(range=30.0),))
     sol = solve(P, S)
 
-    # @btime 17.760 ms (266 allocations: 11.06 MiB)
     plot(sol)
 end
 
-
-@testset "DimDomain is used if dims are irregular" begin
-    # Define an identical but "Irregular" DimArray (the default for a vector index)
-    da_i = DimArray(zeros(20, 30), (X([-19.0:2.0:19.0...]), Y([3.0:3.0:90.0...])))
-
-    # Get the domain from it
-    D = GeoStatsBase.domain(da_i)
-    # It returns a DimDomain
-    @test D isa DimDomain
-
-    # Check the geostatsbase interface works
-    @test GeoStatsBase.nelms(D) == 20 * 30
-    @test GeoStatsBase.ncoords(D) == 2
-    @test GeoStatsBase.coordtype(D) == Float64
-    buffer = [SA[0.0, 0.0] for i in 1:20 * 30]
-    @test GeoStatsBase.coordinates!(buffer, D, 4) == [-13.0, 3.0]
-
-    P = SimulationProblem(da_i, :Z => Float64, 2)
-    S  = DirectGaussSim(:Z=>(variogram=GaussianVariogram(range=30.0),))
-    sol = solve(P, S)
-    # @btime 19.930 ms (265 allocations: 11.06 MiB) 
-    # - a little slower but we are indexing into a vector
-    
-    # But it doesn't plot. This could "just work" using the interface?
-    # plot(sol)
-end
-
-
-@testset "We can just use any `AbstractDimArray` directly as the domain" begin
+@testset "Test DimDomain's GeoStatsBase.jl interface" begin
     da = DimArray(zeros(20, 30), (X([-19.0:2.0:19.0...]), Y([3.0:3.0:90.0...])))
 
-    # Check the geostatsbase interface works
-    @test GeoStatsBase.domain(da) isa DimDomain
-    @test GeoStatsBase.nelms(da) == 20 * 30
-    @test GeoStatsBase.ncoords(da) == 2
-    @test GeoStatsBase.coordtype(da) == Float64
-    buffer = [SA[0.0, 0.0] for i in 1:20 * 30]
-    @test GeoStatsBase.coordinates!(buffer, da, 4) == [-13.0, 3.0]
-
-    P = SimulationProblem(da, :Z => Float64, 2)
-    S  = DirectGaussSim(:Z=>(variogram=GaussianVariogram(range=30.0),))
-    sol = solve(P, S)
+    D = domain(da)
+    @test nelms(D) == 20 * 30
+    @test ncoords(D) == 2
+    @test coordtype(D) == Float64
+    @test coordinates(D, 4) == [-13.0, 3.0]
 end
 
 @testset "interpolate current array size to remove missing" begin
     # Define a regular index DimArray that can hold `missing`
-    A = convert(Array{Union{Float64,Missing}}, rand(20, 30)) 
+    A = convert(Array{Union{Float64,Missing}}, rand(20, 30))
     # Make some values missing
     for i in 1:4:20, j in 1:5:20
         A[i, j] = missing
@@ -174,40 +91,36 @@ end
     da = DimArray(A, (X(LinRange(-19.0, 19.0, 20)), Y(LinRange(3.0, 90.0, 30))), :data)
 
     # interpolate the array with tne Kriging solver
-    result = interpolate(da, Kriging()) 
+    res = interpolate(da, Kriging())
 
-    @test result isa DimArray
-    @test dims(result) == dims(da)
-    @test size(result) == size(da)
-    # We have intepolated the missing values
-    @test any(ismissing, da) == true
-    @test any(ismissing, result) == false
+    # @test res isa DimArray
+    # @test dims(res) == dims(da)
+    # @test size(res) == size(da)
+    # @test any(ismissing, da) == true
+    # @test any(ismissing, res) == false
 
-    # `heatmap` the interpolated array
-    heatmap(result)
-    # Compare the original
     heatmap(da)
+    heatmap(res)
 end
 
 @testset "interpolate to a larger array" begin
     # Define a regular index DimArray
-    A = rand(20, 30) 
+    A = rand(20, 30)
     # Wrap as a DimArray
     da = DimArray(A, (X(LinRange(-19.0, 19.0, 20)), Y(LinRange(3.0, 90.0, 30))), :data)
     newdims = (X(LinRange(-19.0, 19.0, 45))), Y(LinRange(3.0, 90.0, 53))
 
     # interpolate the array with tne Kriging solver and newdims for the domain
-    result = interpolate(da, Kriging(); dims=newdims) 
+    result = interpolate(da, Kriging(); dims=newdims)
 
-    # The return value is a DimArray
-    @test result isa DimArray
-    # `dims` for the returned array wont be identical to `newdims` as they are formatted 
-    # to match the array. But theyre basically the same type:
-    @test dims(result) isa Tuple{<:X{<:LinRange,<:Sampled,Nothing},<:Y{<:LinRange,<:Sampled,Nothing}}
-    # Array is the right size
-    @test size(result) == map(length, newdims)
-    # Dims have the same index as newdims
-    @test index(result) == index(newdims)
+    # @test result isa DimArray
+    # # `dims` for the returned array wont be identical to `newdims` as they are formatted
+    # # to match the array. But theyre basically the same type:
+    # @test dims(result) isa Tuple{<:X{<:LinRange,<:Sampled,Nothing},<:Y{<:LinRange,<:Sampled,Nothing}}
+    # # Array is the right size
+    # @test size(result) == map(length, newdims)
+    # # Dims have the same index as newdims
+    # @test index(result) == index(newdims)
 
     # `heatmap` the interpolated array
     heatmap(result)
@@ -215,33 +128,31 @@ end
     heatmap(da)
 end
 
-@testset "interpolate all arrays in dataset to larger arrays" begin
-    # Define a regular index DimArray
-    layers = (a=rand(20, 30), b=rand(Float32, 20, 30))
-    # Wrap as a DimArray
-    dimz = (X(LinRange(-19.0, 19.0, 20)), Y(LinRange(3.0, 90.0, 30)))
-    ds = DimDataset(layers, dimz)
-    newdims = (X(LinRange(-19.0, 19.0, 45))), Y(LinRange(3.0, 90.0, 53))
+# @testset "interpolate all arrays in dataset to larger arrays" begin
+#     # Define a regular index DimArray
+#     layers = (a=rand(20, 30), b=rand(Float32, 20, 30))
+#     # Wrap as a DimArray
+#     dimz = (X(LinRange(-19.0, 19.0, 20)), Y(LinRange(3.0, 90.0, 30)))
+#     ds = DimDataset(layers, dimz)
+#     newdims = (X(LinRange(-19.0, 19.0, 45))), Y(LinRange(3.0, 90.0, 53))
 
-    # interpolate the array with tne Kriging solver and newdims for the domain
-    result = interpolate(ds, Kriging(); dims=newdims) 
+#     # interpolate the array with tne Kriging solver and newdims for the domain
+#     result = interpolate(ds, Kriging(); dims=newdims)
 
-    # The return value is a DimArray
-    @test result isa DimDataset
-    # `dims` for the returned array wont be identical to `newdims` as they are formatted 
-    # to match the array. But theyre basically the same type:
-    @test dims(result) isa Tuple{<:X{<:LinRange,<:Sampled,Nothing},<:Y{<:LinRange,<:Sampled,Nothing}}
-    # Array is the right size
-    @test size(first(values(result))) == map(length, newdims)
-    # Dims have the same index as newdims
-    @test index(result) == index(newdims)
+#     # The return value is a DimArray
+#     @test result isa DimDataset
+#     # `dims` for the returned array wont be identical to `newdims` as they are formatted
+#     # to match the array. But theyre basically the same type:
+#     @test dims(result) isa Tuple{<:X{<:LinRange,<:Sampled,Nothing},<:Y{<:LinRange,<:Sampled,Nothing}}
+#     # Array is the right size
+#     @test size(first(values(result))) == map(length, newdims)
+#     # Dims have the same index as newdims
+#     @test index(result) == index(newdims)
 
-    # `heatmap` the interpolated arrays
-    heatmap(result[:a])
-    heatmap(result[:b])
-end
-
-
+#     # `heatmap` the interpolated arrays
+#     heatmap(result[:a])
+#     heatmap(result[:b])
+# end
 
 # TODO: test more things
 
@@ -250,29 +161,29 @@ end
 #####################################################################################
 
 
-#= Discussion point: the domain is nearly identical to the table: 
+#= Discussion point: the domain is nearly identical to the table:
 
 struct DimDomain{C} <: AbstractDomain
     dimcolumns::C
 end
 
-struct DimTable{Keys,A,C} <: Tables.AbstractColumns 
+struct DimTable{Keys,A,C} <: Tables.AbstractColumns
     array::A
     dimcolumns::C
 end
 
 This begs the question: why is the domain even separate?
 The key thing that needs to be specified is which columns are domain,
-which are values. 
+which are values.
 
 That could be done with extra interface methods for AbstractTable
 
 - `dimcolnames`/`domaincolnames`
 - `valcolnames`
 
-Or something similar. 
+Or something similar.
 
-Then you can implement coordinates! generically 
+Then you can implement coordinates! generically
 on any table that defines `dimcolnames` or whatever it is.
 
 =#


### PR DESCRIPTION
This is a first attempt to fix some conceptual issues I encountered while reviewing the code.

We miss an implementation for `coordinates!` and an internal design choice in `interpolate` that I added in a comment. Looking at the code now I think we also need a `materializer` trait similar to `Tables.materializer` that takes both the domain and the values table as arguments and returns the original spatial data type, in this case a dimensional array.

I've also noticed that the tables interface may not make sense to dimensional array, but probably dimensional data set? The tables interface is useful when we have multiple columns of variables, and I understood that dimensional arrays contain a single layer or column. You can stack these arrays into datasets to produce a table of columns if I understand correctly.